### PR TITLE
Add chapter selection flow before topic inputs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -66,7 +66,7 @@ export default function ChapterViewer() {
     const hard = slider1;
     const medium = slider2 - slider1;
     const low = 100 - slider2;
-    return `Hard: ${hard}% | Medium: ${medium}% | Low: ${low}%`;
+    return `Hard: ${hard}% Medium: ${medium}% Low: ${low}%`;
   };
 
   const handleGenerate = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -84,6 +84,33 @@ export default function ChapterViewer() {
     });
   };
 
+  const handleContinue = () => {
+    setShowTopics(true);
+    if (activeSubject === null) return;
+    setTopicCounts((prev) => {
+      const copy = prev.map((subj) => subj.map((ch) => [...ch]));
+      copy[activeSubject] = chapters.map((ch) =>
+        Array(ch.topics.length).fill(0)
+      );
+      const topicRefs = [];
+      selectedChapters.forEach((id) => {
+        const chIdx = chapterIndexMap[id];
+        const topicLen = chapters[chIdx].topics.length;
+        for (let i = 0; i < topicLen; i++) {
+          topicRefs.push([chIdx, i]);
+        }
+      });
+      let remaining = TOTAL_QUESTIONS;
+      while (remaining > 0 && topicRefs.length > 0) {
+        const idx = Math.floor(Math.random() * topicRefs.length);
+        const [chIdx, tIdx] = topicRefs[idx];
+        copy[activeSubject][chIdx][tIdx] += 1;
+        remaining--;
+      }
+      return copy;
+    });
+  };
+
   const subjectTotals = topicCounts.map((subj) =>
     subj.reduce((sum, ch) => sum + ch.reduce((s, t) => s + t, 0), 0)
   );
@@ -200,10 +227,7 @@ export default function ChapterViewer() {
                 ))}
             </div>
             {selectedChapters.length > 0 && (
-              <button
-                className="continue-btn"
-                onClick={() => setShowTopics(true)}
-              >
+              <button className="continue-btn" onClick={handleContinue}>
                 Continue
               </button>
             )}

--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,8 @@ export default function ChapterViewer() {
   const [slider2, setSlider2] = useState(66);
   const [showPUC, setShowPUC] = useState(false);
   const [generating, setGenerating] = useState(false);
+  const [selectedChapters, setSelectedChapters] = useState([]);
+  const [showTopics, setShowTopics] = useState(false);
   const initialCounts = subjects.map(() =>
     chapters.map((ch) => ch.topics.map(() => 0))
   );
@@ -89,6 +91,8 @@ export default function ChapterViewer() {
                 setActiveSubject(i);
                 setPucs([]);
                 setOpenChapter(null);
+                setSelectedChapters([]);
+                setShowTopics(false);
                 setShowPUC(true);
               }}
             >
@@ -140,16 +144,14 @@ export default function ChapterViewer() {
                   key={i}
                   className={`puc-button ${pucs.includes(i) ? 'active' : ''}`}
                   onClick={() => {
-                    setPucs((prev) => {
-                      const isActive = prev.includes(i);
-                      const updated = isActive
+                    setPucs((prev) =>
+                      prev.includes(i)
                         ? prev.filter((idx) => idx !== i)
-                        : [...prev, i];
-                      if (i === 0) {
-                        setOpenChapter(isActive ? null : 0);
-                      }
-                      return updated;
-                    });
+                        : [...prev, i]
+                    );
+                    setSelectedChapters([]);
+                    setShowTopics(false);
+                    setOpenChapter(null);
                   }}
                 >
                   {val}
@@ -158,43 +160,80 @@ export default function ChapterViewer() {
             </div>
         </div>
 
-        {/* Chapter Accordion */}
-        <div className={`chapter-container ${pucs.length > 0 ? 'show' : ''}`}>
-          {chapters.map((ch, idx) => (
-            <div className="chapter" key={idx}>
-              <div
-                className="chapter-header"
-                onClick={() => setOpenChapter(openChapter === idx ? null : idx)}
-              >
-                <span>{ch.title}</span>
-                <span className="material-icons arrow-icon">
-                  {openChapter === idx ? 'expand_less' : 'expand_more'}
-                </span>
-              </div>
-              <div className={`topics ${openChapter === idx ? 'show' : ''}`}>
-                {ch.topics.map((topic, i) => (
-                  <div className="topic" key={i}>
-                    <span>{topic}</span>
-                    <input
-                      type="number"
-                      className="topic-input"
-                      min="0"
-                      max={TOTAL_QUESTIONS}
-                      value={
-                        activeSubject !== null
-                          ? topicCounts[activeSubject][idx][i]
-                          : 0
-                      }
-                      onChange={(e) =>
-                        handleTopicCountChange(idx, i, +e.target.value)
-                      }
-                    />
-                  </div>
-                ))}
-              </div>
+        {/* Chapter Selection */}
+        {!showTopics && (
+          <div className={`chapter-container ${pucs.length > 0 ? 'show' : ''}`}>
+            <div className="chapter-buttons">
+              {chapters.map((ch, idx) => (
+                <div
+                  key={idx}
+                  className={`chapter-button ${
+                    selectedChapters.includes(idx) ? 'active' : ''
+                  }`}
+                  onClick={() =>
+                    setSelectedChapters((prev) =>
+                      prev.includes(idx)
+                        ? prev.filter((c) => c !== idx)
+                        : [...prev, idx]
+                    )
+                  }
+                >
+                  {ch.title}
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+            {selectedChapters.length > 0 && (
+              <button
+                className="continue-btn"
+                onClick={() => setShowTopics(true)}
+              >
+                Continue
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Chapter Accordion */}
+        {showTopics && (
+          <div className={`chapter-container show`}>
+            {selectedChapters.map((idx) => (
+              <div className="chapter" key={idx}>
+                <div
+                  className="chapter-header"
+                  onClick={() =>
+                    setOpenChapter(openChapter === idx ? null : idx)
+                  }
+                >
+                  <span>{chapters[idx].title}</span>
+                  <span className="material-icons arrow-icon">
+                    {openChapter === idx ? 'expand_less' : 'expand_more'}
+                  </span>
+                </div>
+                <div className={`topics ${openChapter === idx ? 'show' : ''}`}>
+                  {chapters[idx].topics.map((topic, i) => (
+                    <div className="topic" key={i}>
+                      <span>{topic}</span>
+                      <input
+                        type="number"
+                        className="topic-input"
+                        min="0"
+                        max={TOTAL_QUESTIONS}
+                        value={
+                          activeSubject !== null
+                            ? topicCounts[activeSubject][idx][i]
+                            : 0
+                        }
+                        onChange={(e) =>
+                          handleTopicCountChange(idx, i, +e.target.value)
+                        }
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
         {canGenerate && (
           <button
             className="ai-generate-btn"

--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './ChapterViewer.css';
-
-const subjects = ['Physics', 'Chemistry', 'Mathematics'];
-const chapters = [
-  {
-    title: 'Motion and Laws',
-    topics: ["Newton's Laws", 'Inertia', 'Acceleration']
-  },
-  {
-    title: 'Work, Energy and Power',
-    topics: ['Kinetic Energy', 'Potential Energy', 'Conservation Laws']
-  },
-  {
-    title: 'Oscillations',
-    topics: ['Simple Harmonic Motion', 'Frequency & Amplitude', 'Damped Oscillations']
-  }
-];
+import { fetchYears, fetchSubjects, fetchChapters } from './api';
 
 const TOTAL_QUESTIONS = 10;
 
@@ -26,6 +11,10 @@ const SparkleIcon = ({ className = '', size = 48 }) => (
 );
 
 export default function ChapterViewer() {
+  const [subjects, setSubjects] = useState([]);
+  const [years, setYears] = useState([]);
+  const [chapters, setChapters] = useState([]);
+  const [chapterIndexMap, setChapterIndexMap] = useState({});
   const [activeSubject, setActiveSubject] = useState(null);
   const [pucs, setPucs] = useState([]);
   const [openChapter, setOpenChapter] = useState(null);
@@ -35,10 +24,33 @@ export default function ChapterViewer() {
   const [generating, setGenerating] = useState(false);
   const [selectedChapters, setSelectedChapters] = useState([]);
   const [showTopics, setShowTopics] = useState(false);
-  const initialCounts = subjects.map(() =>
-    chapters.map((ch) => ch.topics.map(() => 0))
-  );
-  const [topicCounts, setTopicCounts] = useState(initialCounts);
+  const [topicCounts, setTopicCounts] = useState([]);
+
+  useEffect(() => {
+    async function loadData() {
+      const [yearRes, subjRes, chapRes] = await Promise.all([
+        fetchYears(),
+        fetchSubjects(),
+        fetchChapters(),
+      ]);
+      const subjNames = subjRes.data.slice(0, 3).map((s) => s.subject_name);
+      setSubjects(subjNames);
+      setYears(yearRes.data);
+      const chaps = chapRes.data.map((ch) => ({
+        ...ch,
+        topics: ['Topic 1', 'Topic 2', 'Topic 3'],
+      }));
+      setChapters(chaps);
+      const indexMap = {};
+      chaps.forEach((ch, idx) => {
+        indexMap[ch.chapter_id] = idx;
+      });
+      setChapterIndexMap(indexMap);
+      const counts = subjNames.map(() => chaps.map(() => Array(3).fill(0)));
+      setTopicCounts(counts);
+    }
+    loadData();
+  }, []);
 
   const handleSliderChange = (index, value) => {
     if (index === 1) {
@@ -62,8 +74,9 @@ export default function ChapterViewer() {
     setTimeout(() => setGenerating(false), 2000);
   };
 
-  const handleTopicCountChange = (chIdx, topicIdx, value) => {
+  const handleTopicCountChange = (chapterId, topicIdx, value) => {
     if (activeSubject === null) return;
+    const chIdx = chapterIndexMap[chapterId];
     setTopicCounts((prev) => {
       const copy = prev.map((subj) => subj.map((ch) => [...ch]));
       copy[activeSubject][chIdx][topicIdx] = value;
@@ -139,48 +152,52 @@ export default function ChapterViewer() {
         {/* PUC Selection */}
         <div className={`puc-container ${showPUC ? 'show' : ''}`}>
           <div className="puc-buttons">
-              {['1st PUC', '2nd PUC'].map((val, i) => (
-                <div
-                  key={i}
-                  className={`puc-button ${pucs.includes(i) ? 'active' : ''}`}
-                  onClick={() => {
-                    setPucs((prev) =>
-                      prev.includes(i)
-                        ? prev.filter((idx) => idx !== i)
-                        : [...prev, i]
-                    );
-                    setSelectedChapters([]);
-                    setShowTopics(false);
-                    setOpenChapter(null);
-                  }}
-                >
-                  {val}
-                </div>
-              ))}
-            </div>
+            {years.map((year) => (
+              <div
+                key={year.year_id}
+                className={`puc-button ${
+                  pucs.includes(year.year_id) ? 'active' : ''
+                }`}
+                onClick={() => {
+                  setPucs((prev) =>
+                    prev.includes(year.year_id)
+                      ? prev.filter((id) => id !== year.year_id)
+                      : [...prev, year.year_id]
+                  );
+                  setSelectedChapters([]);
+                  setShowTopics(false);
+                  setOpenChapter(null);
+                }}
+              >
+                {year.year_name}
+              </div>
+            ))}
+          </div>
         </div>
 
         {/* Chapter Selection */}
         {!showTopics && (
           <div className={`chapter-container ${pucs.length > 0 ? 'show' : ''}`}>
             <div className="chapter-buttons">
-              {chapters.map((ch, idx) => (
-                <div
-                  key={idx}
-                  className={`chapter-button ${
-                    selectedChapters.includes(idx) ? 'active' : ''
-                  }`}
-                  onClick={() =>
-                    setSelectedChapters((prev) =>
-                      prev.includes(idx)
-                        ? prev.filter((c) => c !== idx)
-                        : [...prev, idx]
-                    )
-                  }
-                >
-                  {ch.title}
-                </div>
-              ))}
+              {chapters
+                .filter((ch) => pucs.includes(ch.year_id))
+                .map((ch) => (
+                  <div
+                    key={ch.chapter_id}
+                    className={`chapter-button ${
+                      selectedChapters.includes(ch.chapter_id) ? 'active' : ''
+                    }`}
+                    onClick={() =>
+                      setSelectedChapters((prev) =>
+                        prev.includes(ch.chapter_id)
+                          ? prev.filter((c) => c !== ch.chapter_id)
+                          : [...prev, ch.chapter_id]
+                      )
+                    }
+                  >
+                    {ch.chapter_name}
+                  </div>
+                ))}
             </div>
             {selectedChapters.length > 0 && (
               <button
@@ -196,42 +213,46 @@ export default function ChapterViewer() {
         {/* Chapter Accordion */}
         {showTopics && (
           <div className={`chapter-container show`}>
-            {selectedChapters.map((idx) => (
-              <div className="chapter" key={idx}>
-                <div
-                  className="chapter-header"
-                  onClick={() =>
-                    setOpenChapter(openChapter === idx ? null : idx)
-                  }
-                >
-                  <span>{chapters[idx].title}</span>
-                  <span className="material-icons arrow-icon">
-                    {openChapter === idx ? 'expand_less' : 'expand_more'}
-                  </span>
+            {selectedChapters.map((id) => {
+              const chIdx = chapterIndexMap[id];
+              const chapter = chapters[chIdx];
+              return (
+                <div className="chapter" key={id}>
+                  <div
+                    className="chapter-header"
+                    onClick={() =>
+                      setOpenChapter(openChapter === id ? null : id)
+                    }
+                  >
+                    <span>{chapter.chapter_name}</span>
+                    <span className="material-icons arrow-icon">
+                      {openChapter === id ? 'expand_less' : 'expand_more'}
+                    </span>
+                  </div>
+                  <div className={`topics ${openChapter === id ? 'show' : ''}`}>
+                    {chapter.topics.map((topic, i) => (
+                      <div className="topic" key={i}>
+                        <span>{topic}</span>
+                        <input
+                          type="number"
+                          className="topic-input"
+                          min="0"
+                          max={TOTAL_QUESTIONS}
+                          value={
+                            activeSubject !== null
+                              ? topicCounts[activeSubject][chIdx][i]
+                              : 0
+                          }
+                          onChange={(e) =>
+                            handleTopicCountChange(id, i, +e.target.value)
+                          }
+                        />
+                      </div>
+                    ))}
+                  </div>
                 </div>
-                <div className={`topics ${openChapter === idx ? 'show' : ''}`}>
-                  {chapters[idx].topics.map((topic, i) => (
-                    <div className="topic" key={i}>
-                      <span>{topic}</span>
-                      <input
-                        type="number"
-                        className="topic-input"
-                        min="0"
-                        max={TOTAL_QUESTIONS}
-                        value={
-                          activeSubject !== null
-                            ? topicCounts[activeSubject][idx][i]
-                            : 0
-                        }
-                        onChange={(e) =>
-                          handleTopicCountChange(idx, i, +e.target.value)
-                        }
-                      />
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
         {canGenerate && (

--- a/src/App.js
+++ b/src/App.js
@@ -203,91 +203,91 @@ export default function ChapterViewer() {
         </div>
 
         {/* Chapter Selection */}
-        {!showTopics && (
-          <div className={`chapter-container ${pucs.length > 0 ? 'show' : ''}`}>
-            <div className="chapter-buttons">
-              {chapters
-                .filter((ch) => pucs.includes(ch.year_id))
-                .map((ch) => (
-                  <div
-                    key={ch.chapter_id}
-                    className={`chapter-button ${
-                      selectedChapters.includes(ch.chapter_id) ? 'active' : ''
-                    }`}
-                    onClick={() =>
-                      setSelectedChapters((prev) =>
-                        prev.includes(ch.chapter_id)
-                          ? prev.filter((c) => c !== ch.chapter_id)
-                          : [...prev, ch.chapter_id]
-                      )
-                    }
-                  >
-                    {ch.chapter_name}
-                  </div>
-                ))}
-            </div>
-            {selectedChapters.length > 0 && (
-              <button className="continue-btn" onClick={handleContinue}>
-                Continue
-              </button>
-            )}
+        <div
+          className={`chapter-container ${
+            !showTopics && pucs.length > 0 ? 'show' : ''
+          }`}
+        >
+          <div className="chapter-buttons">
+            {chapters
+              .filter((ch) => pucs.includes(ch.year_id))
+              .map((ch) => (
+                <div
+                  key={ch.chapter_id}
+                  className={`chapter-button ${
+                    selectedChapters.includes(ch.chapter_id) ? 'active' : ''
+                  }`}
+                  onClick={() =>
+                    setSelectedChapters((prev) =>
+                      prev.includes(ch.chapter_id)
+                        ? prev.filter((c) => c !== ch.chapter_id)
+                        : [...prev, ch.chapter_id]
+                    )
+                  }
+                >
+                  {ch.chapter_name}
+                </div>
+              ))}
           </div>
-        )}
+          {selectedChapters.length > 0 && (
+            <button className="continue-btn" onClick={handleContinue}>
+              Continue
+            </button>
+          )}
+        </div>
 
         {/* Chapter Accordion */}
-        {showTopics && (
-          <div className={`chapter-container show`}>
-            <button
-              className="back-btn"
-              onClick={() => {
-                setShowTopics(false);
-                setOpenChapter(null);
-              }}
-            >
-              Back
-            </button>
-            {selectedChapters.map((id) => {
-              const chIdx = chapterIndexMap[id];
-              const chapter = chapters[chIdx];
-              return (
-                <div className="chapter" key={id}>
-                  <div
-                    className="chapter-header"
-                    onClick={() =>
-                      setOpenChapter(openChapter === id ? null : id)
-                    }
-                  >
-                    <span>{chapter.chapter_name}</span>
-                    <span className="material-icons arrow-icon">
-                      {openChapter === id ? 'expand_less' : 'expand_more'}
-                    </span>
-                  </div>
-                  <div className={`topics ${openChapter === id ? 'show' : ''}`}>
-                    {chapter.topics.map((topic, i) => (
-                      <div className="topic" key={i}>
-                        <span>{topic}</span>
-                        <input
-                          type="number"
-                          className="topic-input"
-                          min="0"
-                          max={TOTAL_QUESTIONS}
-                          value={
-                            activeSubject !== null
-                              ? topicCounts[activeSubject][chIdx][i]
-                              : 0
-                          }
-                          onChange={(e) =>
-                            handleTopicCountChange(id, i, +e.target.value)
-                          }
-                        />
-                      </div>
-                    ))}
-                  </div>
+        <div className={`chapter-container ${showTopics ? 'show' : ''}`}>
+          <button
+            className="back-btn"
+            onClick={() => {
+              setShowTopics(false);
+              setOpenChapter(null);
+            }}
+          >
+            Back
+          </button>
+          {selectedChapters.map((id) => {
+            const chIdx = chapterIndexMap[id];
+            const chapter = chapters[chIdx];
+            return (
+              <div className="chapter" key={id}>
+                <div
+                  className="chapter-header"
+                  onClick={() =>
+                    setOpenChapter(openChapter === id ? null : id)
+                  }
+                >
+                  <span>{chapter.chapter_name}</span>
+                  <span className="material-icons arrow-icon">
+                    {openChapter === id ? 'expand_less' : 'expand_more'}
+                  </span>
                 </div>
-              );
-            })}
-          </div>
-        )}
+                <div className={`topics ${openChapter === id ? 'show' : ''}`}>
+                  {chapter.topics.map((topic, i) => (
+                    <div className="topic" key={i}>
+                      <span>{topic}</span>
+                      <input
+                        type="number"
+                        className="topic-input"
+                        min="0"
+                        max={TOTAL_QUESTIONS}
+                        value={
+                          activeSubject !== null
+                            ? topicCounts[activeSubject][chIdx][i]
+                            : 0
+                        }
+                        onChange={(e) =>
+                          handleTopicCountChange(id, i, +e.target.value)
+                        }
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
         {canGenerate && (
           <button
             className="ai-generate-btn"

--- a/src/App.js
+++ b/src/App.js
@@ -213,6 +213,15 @@ export default function ChapterViewer() {
         {/* Chapter Accordion */}
         {showTopics && (
           <div className={`chapter-container show`}>
+            <button
+              className="back-btn"
+              onClick={() => {
+                setShowTopics(false);
+                setOpenChapter(null);
+              }}
+            >
+              Back
+            </button>
             {selectedChapters.map((id) => {
               const chIdx = chapterIndexMap[id];
               const chapter = chapters[chIdx];

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -10,14 +10,25 @@ test('AI Generate button appears after all subjects reach 10 questions', async (
     fireEvent.click(await screen.findByText('I PUC'));
     fireEvent.click(await screen.findByText('Units and Measurements'));
     fireEvent.click(screen.getByText('Continue'));
-    fireEvent.click(screen.getByText('Units and Measurements'));
-    const input = screen.getAllByRole('spinbutton')[0];
-    fireEvent.change(input, { target: { value: '10' } });
     if (idx < subjects.length - 1) {
       expect(screen.queryByText(/AI Generate/i)).toBeNull();
     }
   }
   expect(screen.getByText(/AI Generate/i)).toBeInTheDocument();
+});
+
+test('topics default to a total of 10 questions', async () => {
+  jest.spyOn(Math, 'random').mockReturnValue(0);
+  render(<App />);
+  fireEvent.click(await screen.findByText('PHYSICS'));
+  fireEvent.click(await screen.findByText('I PUC'));
+  fireEvent.click(await screen.findByText('Units and Measurements'));
+  fireEvent.click(screen.getByText('Continue'));
+  fireEvent.click(screen.getByText('Units and Measurements'));
+  const inputs = screen.getAllByRole('spinbutton');
+  const total = inputs.reduce((sum, input) => sum + Number(input.value), 0);
+  expect(total).toBe(10);
+  Math.random.mockRestore();
 });
 
 test('allows selecting both PUC options', async () => {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,42 +1,43 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 
-test('AI Generate button appears after all subjects reach 10 questions', () => {
+test('AI Generate button appears after all subjects reach 10 questions', async () => {
   render(<App />);
-  const subjects = ['Physics', 'Chemistry', 'Mathematics'];
-  subjects.forEach((subj, idx) => {
-    fireEvent.click(screen.getByText(subj));
-    fireEvent.click(screen.getByText('1st PUC'));
-    fireEvent.click(screen.getByText('Motion and Laws'));
+  const subjects = ['PHYSICS', 'CHEMISTRY', 'MATHEMATICS'];
+  for (let idx = 0; idx < subjects.length; idx++) {
+    const subj = subjects[idx];
+    fireEvent.click(await screen.findByText(subj));
+    fireEvent.click(await screen.findByText('I PUC'));
+    fireEvent.click(await screen.findByText('Units and Measurements'));
     fireEvent.click(screen.getByText('Continue'));
-    fireEvent.click(screen.getByText('Motion and Laws'));
+    fireEvent.click(screen.getByText('Units and Measurements'));
     const input = screen.getAllByRole('spinbutton')[0];
     fireEvent.change(input, { target: { value: '10' } });
     if (idx < subjects.length - 1) {
       expect(screen.queryByText(/AI Generate/i)).toBeNull();
     }
-  });
+  }
   expect(screen.getByText(/AI Generate/i)).toBeInTheDocument();
 });
 
-test('allows selecting both PUC options', () => {
+test('allows selecting both PUC options', async () => {
   render(<App />);
-  fireEvent.click(screen.getByText('Physics'));
-  const first = screen.getByText('1st PUC');
-  const second = screen.getByText('2nd PUC');
+  fireEvent.click(await screen.findByText('PHYSICS'));
+  const first = await screen.findByText('I PUC');
+  const second = await screen.findByText('II PUC');
   fireEvent.click(first);
   fireEvent.click(second);
   expect(first.classList.contains('active')).toBe(true);
   expect(second.classList.contains('active')).toBe(true);
 });
 
-test('topics are hidden until chapter header is clicked', () => {
+test('topics are hidden until chapter header is clicked', async () => {
   render(<App />);
-  fireEvent.click(screen.getByText('Physics'));
-  fireEvent.click(screen.getByText('1st PUC'));
-  fireEvent.click(screen.getByText('Motion and Laws'));
+  fireEvent.click(await screen.findByText('PHYSICS'));
+  fireEvent.click(await screen.findByText('I PUC'));
+  fireEvent.click(await screen.findByText('Units and Measurements'));
   fireEvent.click(screen.getByText('Continue'));
-  const header = screen.getByText('Motion and Laws').parentElement;
+  const header = screen.getByText('Units and Measurements').parentElement;
   const topics = header.nextElementSibling;
   expect(topics.classList.contains('show')).toBe(false);
   fireEvent.click(header);

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -7,6 +7,9 @@ test('AI Generate button appears after all subjects reach 10 questions', () => {
   subjects.forEach((subj, idx) => {
     fireEvent.click(screen.getByText(subj));
     fireEvent.click(screen.getByText('1st PUC'));
+    fireEvent.click(screen.getByText('Motion and Laws'));
+    fireEvent.click(screen.getByText('Continue'));
+    fireEvent.click(screen.getByText('Motion and Laws'));
     const input = screen.getAllByRole('spinbutton')[0];
     fireEvent.change(input, { target: { value: '10' } });
     if (idx < subjects.length - 1) {
@@ -27,11 +30,15 @@ test('allows selecting both PUC options', () => {
   expect(second.classList.contains('active')).toBe(true);
 });
 
-test('selecting 1st PUC opens first chapter by default', () => {
+test('topics are hidden until chapter header is clicked', () => {
   render(<App />);
   fireEvent.click(screen.getByText('Physics'));
   fireEvent.click(screen.getByText('1st PUC'));
+  fireEvent.click(screen.getByText('Motion and Laws'));
+  fireEvent.click(screen.getByText('Continue'));
   const header = screen.getByText('Motion and Laws').parentElement;
   const topics = header.nextElementSibling;
+  expect(topics.classList.contains('show')).toBe(false);
+  fireEvent.click(header);
   expect(topics.classList.contains('show')).toBe(true);
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import App from './App';
 
 test('AI Generate button appears after all subjects reach 10 questions', async () => {
@@ -24,8 +24,11 @@ test('topics default to a total of 10 questions', async () => {
   fireEvent.click(await screen.findByText('I PUC'));
   fireEvent.click(await screen.findByText('Units and Measurements'));
   fireEvent.click(screen.getByText('Continue'));
-  fireEvent.click(screen.getByText('Units and Measurements'));
-  const inputs = screen.getAllByRole('spinbutton');
+  const topicsContainer = screen.getByText('Back').parentElement;
+  fireEvent.click(
+    within(topicsContainer).getByText('Units and Measurements')
+  );
+  const inputs = within(topicsContainer).getAllByRole('spinbutton');
   const total = inputs.reduce((sum, input) => sum + Number(input.value), 0);
   expect(total).toBe(10);
   Math.random.mockRestore();
@@ -48,7 +51,10 @@ test('topics are hidden until chapter header is clicked', async () => {
   fireEvent.click(await screen.findByText('I PUC'));
   fireEvent.click(await screen.findByText('Units and Measurements'));
   fireEvent.click(screen.getByText('Continue'));
-  const header = screen.getByText('Units and Measurements').parentElement;
+  const topicsContainer = screen.getByText('Back').parentElement;
+  const header = within(topicsContainer)
+    .getByText('Units and Measurements')
+    .parentElement;
   const topics = header.nextElementSibling;
   expect(topics.classList.contains('show')).toBe(false);
   fireEvent.click(header);
@@ -62,11 +68,21 @@ test('back button returns to chapter selection with previous choices active', as
   fireEvent.click(await screen.findByText('Units and Measurements'));
   fireEvent.click(screen.getByText('Continue'));
   fireEvent.click(screen.getByText('Back'));
-  const first = screen.getByText('Units and Measurements');
+  const selectContainer = screen
+    .getByText('Continue')
+    .closest('.chapter-container');
+  const first = within(selectContainer).getByText('Units and Measurements');
   expect(first.classList.contains('active')).toBe(true);
-  fireEvent.click(screen.getByText('Motion in a Straight Line'));
+  fireEvent.click(
+    within(selectContainer).getByText('Motion in a Straight Line')
+  );
   fireEvent.click(screen.getByText('Continue'));
-  expect(screen.getByText('Units and Measurements')).toBeInTheDocument();
-  expect(screen.getByText('Motion in a Straight Line')).toBeInTheDocument();
+  const topicsContainer = screen.getByText('Back').parentElement;
+  expect(
+    within(topicsContainer).getByText('Units and Measurements')
+  ).toBeInTheDocument();
+  expect(
+    within(topicsContainer).getByText('Motion in a Straight Line')
+  ).toBeInTheDocument();
 });
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -43,3 +43,19 @@ test('topics are hidden until chapter header is clicked', async () => {
   fireEvent.click(header);
   expect(topics.classList.contains('show')).toBe(true);
 });
+
+test('back button returns to chapter selection with previous choices active', async () => {
+  render(<App />);
+  fireEvent.click(await screen.findByText('PHYSICS'));
+  fireEvent.click(await screen.findByText('I PUC'));
+  fireEvent.click(await screen.findByText('Units and Measurements'));
+  fireEvent.click(screen.getByText('Continue'));
+  fireEvent.click(screen.getByText('Back'));
+  const first = screen.getByText('Units and Measurements');
+  expect(first.classList.contains('active')).toBe(true);
+  fireEvent.click(screen.getByText('Motion in a Straight Line'));
+  fireEvent.click(screen.getByText('Continue'));
+  expect(screen.getByText('Units and Measurements')).toBeInTheDocument();
+  expect(screen.getByText('Motion in a Straight Line')).toBeInTheDocument();
+});
+

--- a/src/ChapterViewer.css
+++ b/src/ChapterViewer.css
@@ -96,6 +96,7 @@ body {
       opacity: 0;
       transform: translateY(-10px);
       transition: all 0.7s ease-in-out;
+      pointer-events: none;
     }
 
     .difficulty-container.show,
@@ -105,6 +106,7 @@ body {
       opacity: 1;
       transform: translateY(0);
       margin-top: 20px;
+      pointer-events: auto;
     }
 
     .chapter {

--- a/src/ChapterViewer.css
+++ b/src/ChapterViewer.css
@@ -18,12 +18,14 @@ body {
       100% { background-position: 0% 50%; }
     }
 
-    .card-wrapper {
-      position: relative;
-      width: 420px;
-      padding: 2px;
-      border-radius: 24px;
-    }
+  .card-wrapper {
+    position: relative;
+    width: 100%;
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2px;
+    border-radius: 24px;
+  }
 
     .card-wrapper::before {
       content: '';
@@ -49,27 +51,35 @@ body {
       color: #fff;
     }
 
-    .tabs, .puc-buttons, .chapter-buttons {
-      display: flex;
-      gap: 12px;
-      justify-content: center;
-    }
+  .tabs, .puc-buttons {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+  }
 
-    .chapter-buttons {
-      flex-wrap: wrap;
-    }
+  .chapter-buttons {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    grid-auto-flow: dense;
+  }
 
-    .tab, .puc-button, .chapter-button {
-      padding: 8px 16px;
-      border-radius: 16px;
-      background: rgba(255, 255, 255, 0.1);
-      color: white;
-      font-weight: 500;
-      cursor: pointer;
-      transition: all 0.4s ease;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      font-size: 14px;
-    }
+  .tab, .puc-button, .chapter-button {
+    padding: 8px 16px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.4s ease;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    font-size: 14px;
+  }
+
+  .chapter-button {
+    width: 100%;
+    text-align: center;
+  }
 
     .tab.active, .puc-button.active, .chapter-button.active {
       background: rgba(255, 255, 255, 0.3);

--- a/src/ChapterViewer.css
+++ b/src/ChapterViewer.css
@@ -49,13 +49,17 @@ body {
       color: #fff;
     }
 
-    .tabs, .puc-buttons {
+    .tabs, .puc-buttons, .chapter-buttons {
       display: flex;
       gap: 12px;
       justify-content: center;
     }
 
-    .tab, .puc-button {
+    .chapter-buttons {
+      flex-wrap: wrap;
+    }
+
+    .tab, .puc-button, .chapter-button {
       padding: 8px 16px;
       border-radius: 16px;
       background: rgba(255, 255, 255, 0.1);
@@ -67,7 +71,7 @@ body {
       font-size: 14px;
     }
 
-    .tab.active, .puc-button.active {
+    .tab.active, .puc-button.active, .chapter-button.active {
       background: rgba(255, 255, 255, 0.3);
       box-shadow: 0 0 8px rgba(255, 255, 255, 0.3),
                   0 0 16px rgba(255, 255, 255, 0.15);
@@ -234,7 +238,7 @@ body {
   pointer-events: none;
 }
 
-.ai-generate-btn {
+.ai-generate-btn, .continue-btn {
     margin-top: 20px;
     width: 100%;
     padding: 10px 16px;
@@ -247,7 +251,7 @@ body {
     transition: all 0.3s ease;
   }
 
-.ai-generate-btn:hover {
+.ai-generate-btn:hover, .continue-btn:hover {
   background: rgba(255, 255, 255, 0.2);
 }
 .ai-generate-btn .btn-icon {

--- a/src/ChapterViewer.css
+++ b/src/ChapterViewer.css
@@ -247,22 +247,27 @@ body {
   pointer-events: none;
 }
 
-.ai-generate-btn, .continue-btn {
-    margin-top: 20px;
-    width: 100%;
-    padding: 10px 16px;
-    border-radius: 16px;
-    background: rgba(255, 255, 255, 0.1);
-    color: #fff;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    font-size: 16px;
-    cursor: pointer;
-    transition: all 0.3s ease;
-  }
 
-.ai-generate-btn:hover, .continue-btn:hover {
+ .ai-generate-btn, .continue-btn, .back-btn {
+     margin-top: 20px;
+     width: 100%;
+     padding: 10px 16px;
+     border-radius: 16px;
+     background: rgba(255, 255, 255, 0.1);
+     color: #fff;
+     border: 1px solid rgba(255, 255, 255, 0.3);
+     font-size: 16px;
+     cursor: pointer;
+     transition: all 0.3s ease;
+   }
+
+.ai-generate-btn:hover, .continue-btn:hover, .back-btn:hover {
   background: rgba(255, 255, 255, 0.2);
-}
+ }
+
+ .back-btn {
+   margin-bottom: 20px;
+ }
 .ai-generate-btn .btn-icon {
   margin-right: 8px;
   vertical-align: middle;

--- a/src/ChapterViewer.css
+++ b/src/ChapterViewer.css
@@ -58,10 +58,9 @@ body {
   }
 
   .chapter-buttons {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
     gap: 12px;
-    grid-auto-flow: dense;
   }
 
   .tab, .puc-button, .chapter-button {
@@ -77,8 +76,8 @@ body {
   }
 
   .chapter-button {
-    width: 100%;
     text-align: center;
+    flex: 0 0 auto;
   }
 
     .tab.active, .puc-button.active, .chapter-button.active {

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,294 @@
+export const yearsResponse = {
+    "message": "",
+    "data": [
+        {
+            "year_id": 9,
+            "year_name": "I PUC"
+        },
+        {
+            "year_id": 10,
+            "year_name": "II PUC"
+        }
+    ],
+    "success": true
+};
+
+export const subjectsResponse = {
+    "message": "",
+    "data": [
+        {
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "parent_subject_id": 0
+        },
+        {
+            "subject_id": 13,
+            "subject_name": "CHEMISTRY",
+            "parent_subject_id": 0
+        },
+        {
+            "subject_id": 14,
+            "subject_name": "MATHEMATICS",
+            "parent_subject_id": 0
+        },
+        {
+            "subject_id": 15,
+            "subject_name": "BIOLOGY",
+            "parent_subject_id": 0
+        },
+        {
+            "subject_id": 20,
+            "subject_name": "ZOOLOGY",
+            "parent_subject_id": 15
+        },
+        {
+            "subject_id": 21,
+            "subject_name": "BOTONY",
+            "parent_subject_id": 15
+        }
+    ],
+    "success": true
+};
+
+export const chaptersResponse = {
+    "message": "",
+    "data": [
+        {
+            "chapter_id": 27,
+            "chapter_name": "Units and Measurements",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 28,
+            "chapter_name": "Motion in a Straight Line",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 29,
+            "chapter_name": "Motion in a Plane",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 30,
+            "chapter_name": "Laws of Motion",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 31,
+            "chapter_name": "Work, Energy and Power",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 32,
+            "chapter_name": "System of Particles and Rotational Motion",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 33,
+            "chapter_name": "Gravitation",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 34,
+            "chapter_name": "Mechanical Properties of Solids",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 35,
+            "chapter_name": "Mechanical Properties of Fluids",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 36,
+            "chapter_name": "Thermal Properties of Matter",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 37,
+            "chapter_name": "Thermodynamics",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 38,
+            "chapter_name": "Kinetic Theory",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 39,
+            "chapter_name": "Oscillations",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 40,
+            "chapter_name": "Waves",
+            "year_id": 9,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "I PUC"
+        },
+        {
+            "chapter_id": 41,
+            "chapter_name": "Electric Charges and Fields",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 42,
+            "chapter_name": "Electrostatic Potential and Capacitance",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 43,
+            "chapter_name": "Current Electricity",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 44,
+            "chapter_name": "Moving Charges and Magnetism",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 45,
+            "chapter_name": "Magnetism and Matter",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 46,
+            "chapter_name": "Electromagnetic Induction",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 47,
+            "chapter_name": "Alternating Current",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 48,
+            "chapter_name": "Electromagnetic Waves",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 49,
+            "chapter_name": "Ray Optics and Optical Instruments",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 50,
+            "chapter_name": "Wave Optics",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 51,
+            "chapter_name": "Dual Nature of Radiation and Matter",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 52,
+            "chapter_name": "Atoms",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 53,
+            "chapter_name": "Nuclei",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        },
+        {
+            "chapter_id": 54,
+            "chapter_name": "Semiconductor Electronics: Materials, Devices and Simple Circuits",
+            "year_id": 10,
+            "subject_id": 12,
+            "subject_name": "PHYSICS",
+            "year_name": "II PUC"
+        }
+    ],
+    "success": true
+};
+
+export function fetchYears() {
+    return Promise.resolve(yearsResponse);
+}
+
+export function fetchSubjects() {
+    return Promise.resolve(subjectsResponse);
+}
+
+export function fetchChapters() {
+    return Promise.resolve(chaptersResponse);
+}

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -1,0 +1,13 @@
+import { fetchYears, fetchSubjects, fetchChapters, yearsResponse, subjectsResponse, chaptersResponse } from './api';
+
+test('fetchYears returns PUC years', async () => {
+  await expect(fetchYears()).resolves.toEqual(yearsResponse);
+});
+
+test('fetchSubjects returns subjects list', async () => {
+  await expect(fetchSubjects()).resolves.toEqual(subjectsResponse);
+});
+
+test('fetchChapters returns chapters list', async () => {
+  await expect(fetchChapters()).resolves.toEqual(chaptersResponse);
+});


### PR DESCRIPTION
## Summary
- Introduce chapter selection step after choosing PUC with ability to pick multiple chapters and continue to topic inputs
- Style chapter selection buttons and continue button
- Update tests for new chapter selection workflow

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68935386f53c832e945d034d6946a307